### PR TITLE
Enforce dFPI on installation

### DIFF
--- a/src/background/main.js
+++ b/src/background/main.js
@@ -8,6 +8,7 @@ import {Logger} from "./logger.js";
 import {MessageService} from "./messageService.js";
 import {Network} from "./network.js";
 import {OfflineManager} from "./offline.js";
+import {PrivacySettings} from "./privacySettings.js";
 import {ProxyDownChecker} from "./proxyDownChecker.js";
 import {ProxyStateObserver} from "./proxyStateObserver.js";
 import {StorageUtils} from "./storageUtils.js";
@@ -50,6 +51,7 @@ class Main {
     this.telemetry = new Telemetry(this);
     this.ui = new UI(this);
     this.ipinfo = new IPInfo(this);
+    this.privacySettings = new PrivacySettings(this);
   }
 
   async init() {

--- a/src/background/privacySettings.js
+++ b/src/background/privacySettings.js
@@ -1,0 +1,26 @@
+import {Component} from "./component.js";
+import {Logger} from "./logger.js";
+
+const log = Logger.logger("PrivacySettings");
+
+// Make sure we have dFPI (or stronger) enabled.
+let enforceCookieIsolation = async () => {
+  const initialConfig = await browser.privacy.websites.cookieConfig.get({});
+  log(`initial privacy config: ${initialConfig}`);
+
+  if (initialConfig.value.behavior === "reject_trackers") {
+    // Cookie behavior is too weak. Let's upgrade to dFPI.
+    await browser.privacy.websites.cookieConfig.set({
+      value: {behavior: "reject_trackers_and_partition_foreign"}});
+  }
+
+  const finalConfig = await browser.privacy.websites.cookieConfig.get({});
+  log(`final privacy config: ${finalConfig}`);
+};
+
+export class PrivacySettings extends Component {
+  constructor(receiver) {
+    super(receiver);
+    browser.runtime.onInstalled.addListener(enforceCookieIsolation);
+  }
+}


### PR DESCRIPTION
IP-address hiding and partitioning of cookies are complementary
privacy protections. I would like to propose assuming that, on initial
installation, FPN users would prefer to have cookie partitioning enabled.

(I'm happy to make revisions to this patch as needed.)