### PR TITLE
Update calendar date in sunset message

### DIFF
--- a/src/_locales/en_US/messages.json
+++ b/src/_locales/en_US/messages.json
@@ -92,7 +92,7 @@
     "message": "Back"
   },
   "sunsetMessage": {
-    "message": "Firefox Private Network will be discontinued on June 15, 2023."
+    "message": "Firefox Private Network will be discontinued on June 20, 2023."
   },
   "toastProxyOff": {
     "message": "Firefox Private Network is off."


### PR DESCRIPTION
This PR updates the extension to reflect the recent date change for the FPN wind-down from June 15, 2023 to June 20, 2023.