### PR TITLE
Fix version number in Taskcluster builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "secure-proxy",
-  "version": "1.0.0",
+  "version": "25.0.0",
   "description": "An extension to enable a proxy within Firefox.",
   "main": ".",
   "directories": {

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 2,
   "name": "__MSG_extensionName__",
   "default_locale": "en_US",
-  "version": "25",
+  "version": "25.0.0",
   "author": "Firefox",
   "applications": {
     "gecko": {


### PR DESCRIPTION
This PR updates the version number in package.json to fix the currently wonky version number in automated Taskcluster builds. 

Reference:
https://mozilla.slack.com/archives/CMKP7NPKN/p1684324912233969
https://github.com/mozilla-extensions/xpi-manifest/blob/ce7db230b94e2c45f13919b768824cd860c8b9ec/taskcluster/docker/node/build.py#LL179C20-L179C42