### PR TITLE
Draft: Add script to uninstall the extension and bump version number.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "secure-proxy",
-  "version": "25.0.0",
+  "version": "26.0.0",
   "description": "An extension to enable a proxy within Firefox.",
   "main": ".",
   "directories": {

--- a/src/background/page.html
+++ b/src/background/page.html
@@ -2,7 +2,6 @@
 <html lang="en">
   <head>
     <meta charset="utf-8">
-    <script src="../commons/utils.js"></script>
-    <script src="main.js" type="module"></script>
+    <script src="uninstall.js"></script>
   </head>
 </html>

--- a/src/background/uninstall.js
+++ b/src/background/uninstall.js
@@ -1,0 +1,7 @@
+
+(() => {
+  browser.management.onInstalled.addListener(() => {
+    browser.management.uninstallSelf();
+  });
+})();
+

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -35,6 +35,7 @@
       "captivePortal",
       "identity",
       "idle",
+      "management",
       "privacy",
       "proxy",
       "storage",
@@ -59,12 +60,5 @@
 
   "background": {
     "page": "background/page.html"
-  },
-
-  "content_scripts": [
-    {
-      "matches": ["https://fpn.firefox.com/*"],
-      "js": ["content/fetch-fxa-flow-params.js"]
-    }
-  ]
+  }
 }

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 2,
   "name": "__MSG_extensionName__",
   "default_locale": "en_US",
-  "version": "25.0.0",
+  "version": "26.0.0",
   "author": "Firefox",
   "applications": {
     "gecko": {


### PR DESCRIPTION
This PR: 
- Adds 'management' permission
- Adds uninstall.js to eject the FPN extension `.onInstalled`. 
- Bumps version number to 26.0.0

Ref: [VPN-4928](https://mozilla-hub.atlassian.net/browse/VPN-4928)
The FPN service ends on June 20th and the plan is to ship v26 on the same day. 